### PR TITLE
Propagate error instead of failing if RELP server inaccessible

### DIFF
--- a/relp.go
+++ b/relp.go
@@ -179,6 +179,9 @@ func NewServer(host string, port int, autoAck bool) (server Server, err error) {
 // NewClient - Starts a new RELP client
 func NewClient(host string, port int) (client Client, err error) {
 	client.connection, err = net.Dial("tcp", fmt.Sprintf("%s:%d", host, port))
+	if err != nil {
+		return client, err
+	}
 
 	offer := Message{
 		Txn:     1,


### PR DESCRIPTION
newClient() call causes runtime error in case the server is inaccessible (tcp connection fails). Let's propagate the error to the caller instead.